### PR TITLE
Add a new GS_QUERYSTRING_AUTH param to avoid signing urls

### DIFF
--- a/docs/backends/gcloud.rst
+++ b/docs/backends/gcloud.rst
@@ -127,7 +127,15 @@ a signed (expiring) url.
 
 .. note::
     When using this setting, make sure you have ``fine-grained`` access control enabled on your bucket, 
-    as opposed to ``Uniform`` access control, or else, file  uploads will return with HTTP 400.
+    as opposed to ``Uniform`` access control, or else, file  uploads will return with HTTP 400. If you
+    already have a bucket with ``Uniform`` access control set to public read, please keep 
+    ``GS_DEFAULT_ACL`` to ``None`` and set ``GS_QUERYSTRING_AUTH`` to ``False``.
+
+``GS_QUERYSTRING_AUTH`` (optional, default is True)
+
+If set to ``False`` it forces the url not to be signed. This setting is useful if you need to have a
+bucket configured with ``Uniform`` access control configured with public read. In that case you should
+force the flag ``GS_QUERYSTRING_AUTH = False`` and ``GS_DEFAULT_ACL = None``
 
 ``GS_FILE_CHARSET`` (optional)
 

--- a/storages/backends/gcloud.py
+++ b/storages/backends/gcloud.py
@@ -103,6 +103,7 @@ class GoogleCloudStorage(BaseStorage):
             "location": setting('GS_LOCATION', ''),
             "auto_create_acl": setting('GS_AUTO_CREATE_ACL', 'projectPrivate'),
             "default_acl": setting('GS_DEFAULT_ACL'),
+            "querystring_auth": setting('GS_QUERYSTRING_AUTH', True),
             "expiration": setting('GS_EXPIRATION', timedelta(seconds=86400)),
             "file_overwrite": setting('GS_FILE_OVERWRITE', True),
             "cache_control": setting('GS_CACHE_CONTROL'),
@@ -241,10 +242,12 @@ class GoogleCloudStorage(BaseStorage):
         """
         name = self._normalize_name(clean_name(name))
         blob = self.bucket.blob(name)
+        no_signed_url = (
+            self.default_acl == 'publicRead' or self.querystring_auth is False)
 
-        if not self.custom_endpoint and self.default_acl == 'publicRead':
+        if not self.custom_endpoint and no_signed_url:
             return blob.public_url
-        elif self.default_acl == 'publicRead':
+        elif no_signed_url:
             return '{storage_base_url}/{quoted_name}'.format(
                 storage_base_url=self.custom_endpoint,
                 quoted_name=_quote(name, safe=b"/~"),


### PR DESCRIPTION
To support Uniform permissions buckets on Google Cloud Storage, we need to keep `GS_DEFAULT_ACL` to `None`, but it forces each url to be signed, which is useless since the uniform permission is usually meant to give world read access. This new parameter solves this use case reported in #783, #846 and #909.